### PR TITLE
Configure default headers for AjaxPromise

### DIFF
--- a/app/utils/ajax-promise.js
+++ b/app/utils/ajax-promise.js
@@ -1,38 +1,59 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import Ember from "ember";
+import config from "../config/environment";
 
-export default function (url, type, authToken, data, args, language = "en") {
-  return new Ember.RSVP.Promise(function (resolve, reject) {
-    var headers = {
-      "Accept-Language": language,
-      "X-GOODCITY-APP-NAME": config.APP.NAME,
-      "X-GOODCITY-APP-VERSION": config.APP.VERSION,
-      "X-GOODCITY-APP-SHA": config.APP.SHA
-    };
+let defaultHeaders = {
+  "X-GOODCITY-APP-NAME": config.APP.NAME,
+  "X-GOODCITY-APP-VERSION": config.APP.VERSION,
+  "X-GOODCITY-APP-SHA": config.APP.SHA
+};
+
+function _read(data) {
+  if (typeof data == "function") {
+    return data();
+  }
+  return data;
+}
+
+function AjaxPromise(url, type, authToken, data, args, language = "en") {
+  return new Ember.RSVP.Promise(function(resolve, reject) {
+    var headers = Ember.$.extend({}, _read(defaultHeaders), {
+      "Accept-Language": language
+    });
+
     if (authToken) {
-      headers = Ember.$.extend(headers, {
-        Authorization: "Bearer " + authToken
-      });
+      headers["Authorization"] = "Bearer " + authToken;
     }
 
-    Ember.$.ajax(Ember.$.extend({}, {
-      type: type,
-      dataType: "json",
-      data: data,
-      language: language,
-      url: url.indexOf('http') === -1 ? config.APP.SERVER_PATH + url : url,
-      headers: headers,
-      success: function (data) {
-        Ember.run(function () {
-          resolve(data);
-        });
-      },
-      error: function (jqXHR) {
-        jqXHR.url = url;
-        Ember.run(function () {
-          reject(jqXHR);
-        });
-      }
-    }, args));
+    Ember.$.ajax(
+      Ember.$.extend(
+        {},
+        {
+          type: type,
+          dataType: "json",
+          data: data,
+          language: language,
+          url: url.indexOf("http") === -1 ? config.APP.SERVER_PATH + url : url,
+          headers: headers,
+          success: function(data) {
+            Ember.run(function() {
+              resolve(data);
+            });
+          },
+          error: function(jqXHR) {
+            jqXHR.url = url;
+            Ember.run(function() {
+              reject(jqXHR);
+            });
+          }
+        },
+        args
+      )
+    );
   });
 }
+
+AjaxPromise.setDefaultHeaders = function(headers) {
+  defaultHeaders = headers;
+};
+
+export default AjaxPromise;


### PR DESCRIPTION
We can configure the default headers sent with ajax promises with :

```javascript
AjaxPromise.setDefaultHeaders({
    'X-GOODCITY-APP-NAME': 'stock'
});

// function alternative
AjaxPromise.setDefaultHeaders(() => {
    let headers = { ... };
    if (exampleUser) {
       headers[authorization] = exampleToken;
    }
    return headers;
});

```